### PR TITLE
Remove VS Code extension recommendations

### DIFF
--- a/devfile.yaml
+++ b/devfile.yaml
@@ -2,16 +2,6 @@ schemaVersion: 2.2.2
 metadata:
   name: openjdk-workspace
 
-attributes:
-  # 拡張機能のID (Publisher.ExtensionName) を指定します
-  .vscode/extensions.json: |
-    {
-      "recommendations": [
-        "redhat.mta-java",
-        "redhat.mta-vscode-extension",
-        "redhat.mta-core"
-      ]
-    }
 components:
   - name: tools
     container:


### PR DESCRIPTION
It seems not to work for devspaces. Removed extension recommendations from devfile.